### PR TITLE
Add sponsorship information

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: receiptmanager


### PR DESCRIPTION
As discussed, we would like to go forward and encourage supporters to extend the app's functionality and cover the maintenance costs. We set up an Open Collective organization over at https://opencollective.com/receiptmanager, which will serve as our fiscal host.
A first step is to let people know about the funding opportunities via Github's own `FUNDING.yml` file, which will add a badge to the sidebar of the repository.